### PR TITLE
Sign In Flow & Sign Up Flow

### DIFF
--- a/src/components/atoms/AuthFooter.tsx
+++ b/src/components/atoms/AuthFooter.tsx
@@ -27,7 +27,7 @@ const AuthFooter: React.FC<TextInputProps> = ({ page, ...props }) => {
       <Pressable
         onPress={() =>
           navigation.replace(
-            page === AuthType.SIGNUP ? 'SignInScreen' : 'SignUpScreen'
+            page === AuthType.SIGNUP ? 'SignInScreen' : 'PlanSelectionScreen'
           )
         }>
         <Text color="blue.600">

--- a/src/components/organisms/ModulePickerList.tsx
+++ b/src/components/organisms/ModulePickerList.tsx
@@ -32,7 +32,7 @@ const ModulePickerList = () => {
         <Button onPress={() => navigation.navigate('SignInScreen')}>
           Dummy Sign In Page
         </Button>
-        <Button onPress={() => navigation.navigate('SignUpScreen')}>
+        <Button onPress={() => navigation.navigate('PlanSelectionScreen')}>
           Dummy Sign Up Page
         </Button>
       </HStack>

--- a/src/internationalization/translations/en.json
+++ b/src/internationalization/translations/en.json
@@ -207,7 +207,8 @@
     "isRequired": "{{name}} cannot be left blank",
     "invalid": "Invalid {{name}}",
     "passwordNotMatched": "Password must match",
-    "samePasswordWarning": "New password cannot be the same as the old password"
+    "samePasswordWarning": "New password cannot be the same as the old password",
+    "wrongCredentials": "Incorrect phone number / password"
   },
   "cameraPermissions": {
     "title": "Need Camera Permission",

--- a/src/internationalization/translations/th.json
+++ b/src/internationalization/translations/th.json
@@ -207,7 +207,8 @@
     "isRequired": "กรุณากรอก{{name}}",
     "invalid": "{{name}}ไม่ถูกต้อง",
     "passwordNotMatched": "รหัสผ่านไม่ตรงกัน",
-    "samePasswordWarning": "รหัสผ่านใหม่ไม่สามารถตรงกับรหัสผ่านเก่าได้"
+    "samePasswordWarning": "รหัสผ่านใหม่ไม่สามารถตรงกับรหัสผ่านเก่าได้",
+    "wrongCredentials": "หมายเลขโทรศัพท์ / รหัสผ่านไม่ถูกต้อง"
   },
   "cameraPermissions": {
     "title": "โปรดอนุญาตการเข้าถึงกล้องของอุปกรณ์นี้",

--- a/src/navigation/MainNavigation.tsx
+++ b/src/navigation/MainNavigation.tsx
@@ -189,6 +189,7 @@ const MainNavigation = () => {
             <Stack.Screen
               name="SignUpScreen"
               component={SignUpScreen}
+              initialParams={{ isElderly: true }}
               options={{
                 title: 'Sign Up',
                 headerShown: false

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -30,7 +30,7 @@ export type RootStackParamList = {
   ConnectScreen: undefined;
 
   SignInScreen: undefined;
-  SignUpScreen: undefined;
+  SignUpScreen: { isElderly: boolean };
   ForgotPasswordScreen: undefined;
 
   PlanSelectionScreen: undefined;

--- a/src/screens/PlanSelectionScreen.tsx
+++ b/src/screens/PlanSelectionScreen.tsx
@@ -36,7 +36,9 @@ const PlanSelectionScreen = () => {
             ]}
             buttonText={t('planSelection.selfCareButtonText')}
             buttonColor={null}
-            handlePress={() => navigation.navigate('ProfileScreen')}
+            handlePress={() =>
+              navigation.navigate('SignUpScreen', { isElderly: true })
+            }
           />
           <PlanSelectionCard
             backgroundColor="#fff"
@@ -49,7 +51,9 @@ const PlanSelectionScreen = () => {
             ]}
             buttonText={t('planSelection.elderlyCareButtonText')}
             buttonColor="#ff9145"
-            handlePress={() => navigation.navigate('ProfileScreen')}
+            handlePress={() =>
+              navigation.navigate('SignUpScreen', { isElderly: false })
+            }
           />
           <Box flex={1} />
           <AuthFooter page={AuthType.SIGNUP} />

--- a/src/screens/SignInScreen.tsx
+++ b/src/screens/SignInScreen.tsx
@@ -21,20 +21,45 @@ import images from '../assets/images';
 import useDimensions from '../hooks/useDimensions';
 import { useTranslation } from 'react-i18next';
 import Ionicons from 'react-native-vector-icons/Ionicons';
+import { useNavigation } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { RootStackParamList } from '../navigation/types';
+import { signIn } from '../utils/auth';
+import { useAuthentication } from '../hooks/useAuthentication';
 
 const SignInScreen = () => {
   const {
     control,
     formState: { errors },
-    handleSubmit
+    handleSubmit,
+    setError
   } = useForm();
 
   const { ScreenWidth } = useDimensions();
   const { t } = useTranslation();
+  const { setToken } = useAuthentication();
+  const navigation =
+    useNavigation<NativeStackNavigationProp<RootStackParamList>>();
 
   const [showPassword, setShowPassword] = useState<boolean>(false);
 
-  const onFormSubmit = useCallback(() => null, []);
+  const onFormSubmit = useCallback(async (data) => {
+    const { phoneNumber, password } = data;
+    const signInResponse = await signIn(phoneNumber, password);
+    if (signInResponse?.data?.token) {
+      setToken(signInResponse.data.token);
+      navigation.replace('TabNavigation');
+    } else {
+      setError('phoneNumber', {
+        type: 'manual',
+        message: t('error.wrongCredentials')
+      });
+      setError('password', {
+        type: 'manual',
+        message: t('error.wrongCredentials')
+      });
+    }
+  }, []);
 
   return (
     <SafeAreaView>

--- a/src/screens/SignUpScreen.tsx
+++ b/src/screens/SignUpScreen.tsx
@@ -82,7 +82,7 @@ const informationList: InformationList[][] = [
   ]
 ];
 
-const SignUpScreen = () => {
+const SignUpScreen = ({ route }) => {
   const {
     control,
     formState: { errors },
@@ -135,14 +135,15 @@ const SignUpScreen = () => {
       }
       if (signUpStage === 2) setSignUpStage((prev) => prev + 1);
       if (signUpStage === 3) {
-        const payload = {
+        const { isElderly } = route?.params ?? true;
+        const payload: SignUpPayload = {
           imageid: '',
           fname: name,
           lname: lastName,
           dname: displayName,
           bday: date.toISOString().substring(0, 10),
           gender: gender,
-          isElderly: true,
+          isElderly,
           healthCondition: healthIssues,
           bloodType: bloodType === 'N/A' ? '' : bloodType,
           personalMedication: personalMedicine,
@@ -178,7 +179,7 @@ const SignUpScreen = () => {
         } else navigation.replace('TabNavigation');
       }
     },
-    [signUpStage, newProfileImage, navigation, setSignUpStage, client]
+    [signUpStage, newProfileImage, navigation, setSignUpStage, client, route]
   );
 
   return (

--- a/src/screens/SignUpScreen.tsx
+++ b/src/screens/SignUpScreen.tsx
@@ -23,6 +23,7 @@ import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RootStackParamList } from '../navigation/types';
 import { UserContext } from '../contexts/UserContext';
+import { signUp, SignUpPayload } from '../utils/auth';
 
 interface InformationList {
   label: string;
@@ -153,7 +154,7 @@ const SignUpScreen = ({ route }) => {
           password: password
         };
 
-        const signUpResponse = await client.post('/user/signUp', payload);
+        const signUpResponse = await signUp(payload);
         if (signUpResponse.data) {
           setToken(signUpResponse.data.token);
           setSignUpStage((prev) => prev + 1);

--- a/src/screens/SignUpScreen.tsx
+++ b/src/screens/SignUpScreen.tsx
@@ -124,6 +124,7 @@ const SignUpScreen = ({ route }) => {
         previousVaccinations,
         bloodType
       } = data;
+
       if (signUpStage === 1) {
         if (data.password === data.confirmPassword) {
           setSignUpStage((prev) => prev + 1);
@@ -134,9 +135,11 @@ const SignUpScreen = ({ route }) => {
           });
         }
       }
+
       if (signUpStage === 2) setSignUpStage((prev) => prev + 1);
+
       if (signUpStage === 3) {
-        const { isElderly } = route?.params ?? true;
+        const { isElderly } = route?.params;
         const payload: SignUpPayload = {
           imageid: '',
           fname: name,

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,0 +1,21 @@
+import { client } from '../config/axiosConfig';
+
+export interface SignUpPayload {
+  imageid: string;
+  fname: string;
+  lname: string;
+  dname: string;
+  bday: string;
+  gender: string;
+  isElderly: boolean;
+  healthCondition: string;
+  bloodType: string;
+  personalMedication: string;
+  allergy: string;
+  vaccine: string;
+  phone: string;
+  password: string;
+}
+
+export const signUp = async (payload: SignUpPayload) =>
+  await client.post('/user/signUp', payload);

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -51,6 +51,5 @@ export const requestOTP = async (phone: string) =>
 
 export const verifyOTP = async (token: string, otp: string) => {
   const payload = { token, pin: otp };
-  return { data: { status: payload.pin === '000000' ? 'success' : 'fail' } }; // OTP is by default 000000 for staging
-  //   return await client.post('/otp/verifyOtp', payload);
+    return await client.post('/otp/verifyOtp', payload);
 };

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -17,11 +17,34 @@ export interface SignUpPayload {
   password: string;
 }
 
+export interface SignInPayload {
+  imageid: string;
+  fname: string;
+  lname: string;
+  dname: string;
+  bday: string;
+  gender: string;
+  isElderly: boolean;
+  healthCondition: string;
+  bloodType: string;
+  personalMedication: string;
+  allergy: string;
+  vaccine: string;
+  phone: string;
+  password: string;
+}
+
 export const signUp = async (payload: SignUpPayload) =>
   await client.post('/user/signUp', payload);
+
+export const signIn = async (payload: SignInPayload) =>
+  await client.post('/user/login', payload);
 
 export const requestOTP = async (phone: string) =>
   await client.get(`/otp/request/${phone}`);
 
-export const verifyOTP = async (token: string, otp: string) =>
-  await client.post('/otp/verifyOtp', { token, pin: otp });
+export const verifyOTP = async (token: string, otp: string) => {
+  const payload = { token, pin: otp };
+  return { data: { status: payload.pin === '000000' ? 'success' : 'fail' } }; // OTP is by default 000000 for staging
+  //   return await client.post('/otp/verifyOtp', payload);
+};

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -19,3 +19,9 @@ export interface SignUpPayload {
 
 export const signUp = async (payload: SignUpPayload) =>
   await client.post('/user/signUp', payload);
+
+export const requestOTP = async (phone: string) =>
+  await client.get(`/otp/request/${phone}`);
+
+export const verifyOTP = async (token: string, otp: string) =>
+  await client.post('/otp/verifyOtp', { token, pin: otp });

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -37,8 +37,14 @@ export interface SignInPayload {
 export const signUp = async (payload: SignUpPayload) =>
   await client.post('/user/signUp', payload);
 
-export const signIn = async (payload: SignInPayload) =>
-  await client.post('/user/login', payload);
+export const signIn = async (phone: string, password: string) => {
+  try {
+    return await client.post('/user/login', { phone, password });
+  } catch (e) {
+    const error: { status: number } = e as { status: number };
+    return { data: { status: error.status } };
+  }
+};
 
 export const requestOTP = async (phone: string) =>
   await client.get(`/otp/request/${phone}`);


### PR DESCRIPTION
- Complete Sign In Flow
  - add error message for failed login
![image](https://user-images.githubusercontent.com/41866236/160278322-d605df1d-2c7d-4c2e-9bc4-e2f2bec4167d.png)
  - navigate to TabNavigation after login success
- Sign Up Flow without real OTP and profile image upload
  - Include plan selection screen in the flow
  - Enter OTP 00000 to continue
  - Still need to skip Profile upload