### PR TITLE
Client-Side Changing Caretakers' Display Name, UserLinkScreen Data Handling

### DIFF
--- a/src/components/atoms/Input.tsx
+++ b/src/components/atoms/Input.tsx
@@ -4,9 +4,10 @@ import React from 'react';
 type InputBoxProps = {
   name: string;
   placeholder?: string;
+  onChangeText?: any;
 };
 
-const InputBox = ({ name }: InputBoxProps) => {
+const InputBox = ({ name, onChangeText }: InputBoxProps) => {
   return (
     <View>
       <Box flexDir="row">
@@ -22,6 +23,7 @@ const InputBox = ({ name }: InputBoxProps) => {
           size="xl"
           fontSize="sm"
           padding={3}
+          onChangeText={onChangeText}
         />
       </Box>
     </View>

--- a/src/components/atoms/RemButton.tsx
+++ b/src/components/atoms/RemButton.tsx
@@ -8,6 +8,7 @@ import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RootStackParamList } from '../../navigation/types';
 import { ElderlyContext } from '../../contexts/ElderlyContext';
+import { removeDisplayName } from '../../utils/elderly/displayNames'
 
 type remButtonProps = {
   fullName: string
@@ -33,6 +34,7 @@ const RemButton = ({ fullName, cid }: remButtonProps) => {
   const { user } = useContext(UserContext);
 
   async function handlePressDelete() {
+    await removeDisplayName(cid)
     await client.delete('/user/relationship', { data: { eid: user?.uid, cid: cid } })
       .then(() => {
         setCaretakerList(caretakerList.filter(ele => ele.uid !== cid))

--- a/src/components/organisms/CaretakerCard.tsx
+++ b/src/components/organisms/CaretakerCard.tsx
@@ -1,11 +1,13 @@
-import React from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { Image, View, Text, Button } from 'native-base';
-import { useNavigation } from '@react-navigation/native';
+import { useIsFocused, useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RootStackParamList } from '../../navigation/types';
 import { StyleSheet } from 'react-native';
 import EditButton from '../atoms/EditButton';
 import { useTranslation } from 'react-i18next';
+import { getDisplayName } from '../../utils/elderly/displayNames';
+import useAsyncEffect from '../../hooks/useAsyncEffect';
 
 const ProfilePic = require('../../assets/images/profile.png');
 
@@ -35,6 +37,23 @@ const UserCard = ({
 
   const { t } = useTranslation();
 
+  const isFocused = useIsFocused();
+
+  const [displayName, setDisplayName] = useState<string>('');
+
+  useAsyncEffect(async () => {
+    setDisplayName(await getDisplayName(uid));
+  }, [isFocused]);
+
+  useEffect(() => {
+    console.log(displayName);
+  }, [displayName]);
+
+  const handleDisplay = () => {
+    if (displayName == '') return name;
+    return displayName;
+  };
+
   return (
     <View
       flexDir="row"
@@ -55,20 +74,20 @@ const UserCard = ({
           alt="Profile Picture"
         />
         <Text flex={1} flexWrap="wrap" fontSize="lg" numberOfLines={1}>
-          {name}
+          {handleDisplay()}
         </Text>
       </>
       <EditButton
         onPress={() =>
           navigation.navigate('EditCaretakerScreen', {
-              info: {
+            info: {
               fullName: fullName,
               gender: gender,
               bdate: bdate,
               phone: phone,
               imageId: imageId,
               cid: uid
-              }
+            }
           })
         }
       />

--- a/src/components/organisms/CaretakerCard.tsx
+++ b/src/components/organisms/CaretakerCard.tsx
@@ -45,10 +45,6 @@ const UserCard = ({
     setDisplayName(await getDisplayName(uid));
   }, [isFocused]);
 
-  useEffect(() => {
-    console.log(displayName);
-  }, [displayName]);
-
   const handleDisplay = () => {
     if (displayName == '') return name;
     return displayName;

--- a/src/components/organisms/ElderlyCard.tsx
+++ b/src/components/organisms/ElderlyCard.tsx
@@ -57,15 +57,8 @@ const ElderlyCard = ({
           {name}
         </Text>
       </>
-      {userIsElderly ? (
-        <Button onPress={handlePressTakeCare}>{t('home.takeCare')}</Button>
-      ) : (
-        <EditButton
-          onPress={() =>
-            navigation.navigate('EditCaretakerScreen', { itemId: name })
-          }
-        />
-      )}
+
+      <Button onPress={handlePressTakeCare}>{t('home.takeCare')}</Button>
     </View>
   );
 };

--- a/src/contexts/ElderlyContext.tsx
+++ b/src/contexts/ElderlyContext.tsx
@@ -6,7 +6,6 @@ import useAsyncEffect from './../hooks/useAsyncEffect';
 import { getElderlyCode } from '../utils/elderly/code';
 import { getCaretakerList } from '../utils/elderly/caretakerList';
 import { User } from '../dto/modules/user.dto';
-import { getDisplayName } from '../utils/elderly/displayNames';
 
 export interface ElderlyContextProps {
   elderlyProfile: ElderlyHomeProfile | undefined;

--- a/src/contexts/ElderlyContext.tsx
+++ b/src/contexts/ElderlyContext.tsx
@@ -6,7 +6,7 @@ import useAsyncEffect from './../hooks/useAsyncEffect';
 import { getElderlyCode } from '../utils/elderly/code';
 import { getCaretakerList } from '../utils/elderly/caretakerList';
 import { User } from '../dto/modules/user.dto';
-import { ElderlyLinkCode } from '../dto/modules/code.dto';
+import { getDisplayName } from '../utils/elderly/displayNames';
 
 export interface ElderlyContextProps {
   elderlyProfile: ElderlyHomeProfile | undefined;
@@ -27,14 +27,15 @@ const ElderlyContextProvider = ({ ...props }) => {
   const [elderlyCode, setElderlyCode] = useState<string>('');
   const [caretakerList, setCaretakerList] = useState<User[]>([]); // list all caretaker's data
 
+
   //If the user is elderly, get moduleIds and all available modules from the backend.
   useAsyncEffect(async () => {
     const _elderlyProfile = await getElderlyProfile();
     const _elderlyCode = await getElderlyCode();
     const _caretakerList = await getCaretakerList();
 
-    setElderlyCode(_elderlyCode)
-    setCaretakerList(_caretakerList)
+    setElderlyCode(_elderlyCode);
+    setCaretakerList(_caretakerList);
 
     if (_elderlyProfile.listModuleid) {
       _elderlyProfile.listModuleid = [0, ..._elderlyProfile?.listModuleid, 100];

--- a/src/screens/EditCaretakerScreen.tsx
+++ b/src/screens/EditCaretakerScreen.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, Text, ScrollView } from 'native-base';
+import { View, Text, ScrollView, Button } from 'native-base';
 import RemButton from '../components/atoms/RemButton';
 import Divider from '../components/atoms/Divider';
 import InputBox from '../components/atoms/Input';
@@ -8,24 +8,38 @@ import KeyboardAvoidingView from '../components/atoms/KeyboardAvoidingView';
 import { useTranslation } from 'react-i18next';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { RootStackParamList } from '../navigation/types';
+import { storeDisplayName } from '../utils/elderly/displayNames';
 
-const EditCaretakerScreen = ({route}:NativeStackScreenProps<RootStackParamList, 'EditCaretakerScreen'>) => {
+const EditCaretakerScreen = ({
+  route
+}: NativeStackScreenProps<RootStackParamList, 'EditCaretakerScreen'>) => {
+  const { info } = route.params;
 
-  // WIP
-  const {info} = route.params;
+  const handleChange = (text: string) => {
+    storeDisplayName(info.cid, text);
+  };
 
   const { t } = useTranslation();
   return (
     <KeyboardAvoidingView>
       <ScrollView>
         <View bgColor="#FAFAFA">
-          <ProfileInfoCard fullName={info.fullName} gender={info.gender} bdate={info.bdate} phone={info.phone} imageId={info.imageId}/>
+          <ProfileInfoCard
+            fullName={info.fullName}
+            gender={info.gender}
+            bdate={info.bdate}
+            phone={info.phone}
+            imageId={info.imageId}
+          />
           <Divider />
           <View paddingX={5}>
-            <InputBox name={t('userForm.editName')} />
+            <InputBox
+              name={t('userForm.editName')}
+              onChangeText={handleChange}
+            />
           </View>
           <Divider />
-          <RemButton fullName={info.fullName} cid={info.cid}/>
+          <RemButton fullName={info.fullName} cid={info.cid} />
         </View>
       </ScrollView>
     </KeyboardAvoidingView>

--- a/src/screens/UserLinkScreen.tsx
+++ b/src/screens/UserLinkScreen.tsx
@@ -9,9 +9,9 @@ import UserCard from '../components/organisms/CaretakerCard';
 import { ElderlyContext } from '../contexts/ElderlyContext';
 
 const UserLinkScreen = () => {
-  // todo: connect with backend's data
+  
   const {caretakerList, setCaretakerList} = useContext(ElderlyContext);
-  console.log(caretakerList);
+  
   const navigation =
     useNavigation<NativeStackNavigationProp<RootStackParamList>>();
   return (

--- a/src/screens/UserLinkScreen.tsx
+++ b/src/screens/UserLinkScreen.tsx
@@ -1,50 +1,56 @@
 import React, { useContext } from 'react';
-import { View, ScrollView, Button, FlatList } from 'native-base';
+import { View, Button, FlatList } from 'native-base';
 import AddButton from '../components/atoms/AddButton';
-import Card from '../components/organisms/CaretakerCard';
-import { useNavigation } from '@react-navigation/native';
+import { useNavigation, useIsFocused } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RootStackParamList } from '../navigation/types';
 import UserCard from '../components/organisms/CaretakerCard';
 import { ElderlyContext } from '../contexts/ElderlyContext';
+import useAsyncEffect from '../hooks/useAsyncEffect';
+import { getCaretakerList } from '../utils/elderly/caretakerList';
 
 const UserLinkScreen = () => {
-  
-  const {caretakerList, setCaretakerList} = useContext(ElderlyContext);
-  
+  const isFocused = useIsFocused();
+
+  const { caretakerList, setCaretakerList } = useContext(ElderlyContext);
+
+  useAsyncEffect(async () => {
+    setCaretakerList(await getCaretakerList());
+  }, [isFocused]);
+
   const navigation =
     useNavigation<NativeStackNavigationProp<RootStackParamList>>();
   return (
-      <View bgColor="#FAFAFA" flex={1}>
-        <FlatList
-          data={caretakerList}
-          renderItem={({ item }) => (
-            <View alignItems="center">
-              <UserCard
-                name={item.dname}
-                fullName={`${item.fname} ${item.lname}`}
-                imageId={item.imageid}
-                userIsElderly={false}
-                gender={item.gender}
-                bdate={item.bday}
-                phone={item.phone}
-                uid={item.uid}
-              />
-            </View>   
-          )}
-          keyExtractor={(_, key) => key.toString()}
-        />
-        <AddButton />
+    <View bgColor="#FAFAFA" flex={1}>
+      <FlatList
+        data={caretakerList}
+        renderItem={({ item }) => (
+          <View alignItems="center">
+            <UserCard
+              name={item.dname}
+              fullName={`${item.fname} ${item.lname}`}
+              imageId={item.imageid}
+              userIsElderly={false}
+              gender={item.gender}
+              bdate={item.bday}
+              phone={item.phone}
+              uid={item.uid}
+            />
+          </View>
+        )}
+        keyExtractor={(_, key) => key.toString()}
+      />
+      <AddButton />
 
-        {/* Placeholder Navigation */}
-        <View flexDir="row" justifyContent="center">
-          <Button
-            width="90%"
-            onPress={() => navigation.navigate('ConnectElderlyScreen')}>
-            Go to Caretaker's Page
-          </Button>
-        </View>
+      {/* Placeholder Navigation */}
+      <View flexDir="row" justifyContent="center">
+        <Button
+          width="90%"
+          onPress={() => navigation.navigate('ConnectElderlyScreen')}>
+          Go to Caretaker's Page
+        </Button>
       </View>
+    </View>
   );
 };
 export default UserLinkScreen;

--- a/src/utils/elderly/caretakerList.ts
+++ b/src/utils/elderly/caretakerList.ts
@@ -2,6 +2,10 @@ import { client } from '../../config/axiosConfig';
 import { User } from '../../dto/modules/user.dto';
 
 export async function getCaretakerList(): Promise<User[]> {
-  const { data } = await client.get('/user/relationship/caretaker');
-  return data;
+  try {
+    const { data } = await client.get('/user/relationship/caretaker');
+    return data;
+  } catch (err) {
+    throw Error('Cannot retrieve list of caretakers');
+  }
 }

--- a/src/utils/elderly/code.ts
+++ b/src/utils/elderly/code.ts
@@ -1,6 +1,10 @@
 import { client } from '../../config/axiosConfig';
 
 export async function getElderlyCode(): Promise<string> {
-  const { data } = await client.get('/link/elderlycode');
-  return data.code;
+  try {
+    const { data } = await client.get('/link/elderlycode');
+    return data.code;
+  } catch (err) {
+    throw Error('Cannot retrieve code');
+  }
 }

--- a/src/utils/elderly/displayNames.ts
+++ b/src/utils/elderly/displayNames.ts
@@ -1,14 +1,5 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
-export interface DisplayName {
-  uid: number;
-  newDisplayName: string;
-}
-
-export interface DisplayNameList {
-  DisplayList: DisplayName[];
-}
-
 export const storeDisplayName = async (key: number, value: string) => {
   try {
     await AsyncStorage.setItem(`${key}`, value);
@@ -35,15 +26,13 @@ export const removeDisplayName = async (key: number) => {
   } catch (e) {
     console.log(e);
   }
-
-  console.log('Done.');
 };
 
 export const getAllKeys = async () => {
   try {
     let keys = await AsyncStorage.getAllKeys();
-    return keys
+    return keys;
   } catch (e) {
-    console.log(e)
+    console.log(e);
   }
-}
+};

--- a/src/utils/elderly/displayNames.ts
+++ b/src/utils/elderly/displayNames.ts
@@ -1,0 +1,49 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+export interface DisplayName {
+  uid: number;
+  newDisplayName: string;
+}
+
+export interface DisplayNameList {
+  DisplayList: DisplayName[];
+}
+
+export const storeDisplayName = async (key: number, value: string) => {
+  try {
+    await AsyncStorage.setItem(`${key}`, value);
+  } catch (e) {
+    console.log(e);
+  }
+};
+
+export const getDisplayName = async (key: number): Promise<string> => {
+  try {
+    const value = await AsyncStorage.getItem(`${key}`);
+    if (value !== null) {
+      return value as string;
+    }
+  } catch (e) {
+    console.log(e);
+  }
+  return '';
+};
+
+export const removeDisplayName = async (key: number) => {
+  try {
+    await AsyncStorage.removeItem(`${key}`);
+  } catch (e) {
+    console.log(e);
+  }
+
+  console.log('Done.');
+};
+
+export const getAllKeys = async () => {
+  try {
+    let keys = await AsyncStorage.getAllKeys();
+    return keys
+  } catch (e) {
+    console.log(e)
+  }
+}


### PR DESCRIPTION
**Notes:**

- Caretaker's Display Name is shown on UserLinkScreen's cards
- Caretaker's Display Name is set through input field in EditCaretakerScreen & stored in AsyncStorage with key as uid of that caretaker.
- On deletion of caretaker in EditCaretakerScreen, key-value pair in AsyncStorage of that caretaker is removed.
- UserLinkScreen now displays newly linked caretakers on reentering the screen.