### PR TITLE
Complete sign in and sign out auth flow

### DIFF
--- a/src/constants/AlertMessages.ts
+++ b/src/constants/AlertMessages.ts
@@ -26,7 +26,7 @@ export const AlertMessages = {
     primaryButton: i18n.t('updateProfileSuccess.primaryButton'),
     secondaryButton: i18n.t('updateProfileSuccess.secondaryButton')
   },
-  updateProileError: {
+  updateProfileError: {
     header: i18n.t('updateProfileError.header'),
     body: i18n.t('updateProfileError.body'),
     primaryButton: i18n.t('updateProfileError.primaryButton'),

--- a/src/contexts/UserContext.tsx
+++ b/src/contexts/UserContext.tsx
@@ -6,7 +6,7 @@ import { User } from './../dto/modules/user.dto';
 
 export interface UserContextProps {
   user: User | undefined;
-  setUser: (value: User) => void;
+  setUser: (value: User | undefined) => void;
   isElderly: boolean | undefined;
   userToken: string;
   getUserProfile: () => Promise<void>;

--- a/src/navigation/MainNavigation.tsx
+++ b/src/navigation/MainNavigation.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { RootStackParamList } from './types';
 import { NavigationContainer, DefaultTheme } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
@@ -38,7 +38,8 @@ const MainNavigation = () => {
   const Stack = createNativeStackNavigator<RootStackParamList>();
   const { t } = useTranslation();
   const { setShowSettingsTourguide } = useContext(TourguideContext);
-  const { user } = useContext(UserContext);
+  const { user, userToken } = useContext(UserContext);
+  const [showNav, setShowNav] = useState<boolean>(true);
 
   const navigationTheme = {
     ...DefaultTheme,
@@ -48,6 +49,14 @@ const MainNavigation = () => {
     }
   };
 
+  useEffect(() => {
+    setShowNav(false);
+    setTimeout(() => {
+      setShowNav(true);
+    }, 0);
+  }, [userToken]);
+
+  if (!showNav) return null;
   return (
     <NavigationContainer theme={navigationTheme}>
       <Stack.Navigator>
@@ -257,6 +266,23 @@ const MainNavigation = () => {
               name="OnBoardingScreen"
               component={OnBoardingScreen}
               options={{ headerShown: false }}
+            />
+            <Stack.Screen
+              name="SignInScreen"
+              component={SignInScreen}
+              options={{
+                title: 'Sign In',
+                headerShown: false
+              }}
+            />
+            <Stack.Screen
+              name="SignUpScreen"
+              component={SignUpScreen}
+              initialParams={{ isElderly: true }}
+              options={{
+                title: 'Sign Up',
+                headerShown: false
+              }}
             />
           </>
         )}

--- a/src/screens/OnBoardingScreen.tsx
+++ b/src/screens/OnBoardingScreen.tsx
@@ -162,7 +162,7 @@ const OnBoardingScreen = () => {
             size="lg"
             onPress={async () => {
               navigation.navigate('SignInScreen');
-              AsyncStorage.setItem('viewedOnboarding', 'true');
+              await AsyncStorage.setItem('viewedOnboarding', 'true');
             }}>
             <Text bold fontWeight="600" fontSize="lg" color="#fff">
               {t('onBoarding.startButton')}

--- a/src/screens/OnBoardingScreen.tsx
+++ b/src/screens/OnBoardingScreen.tsx
@@ -7,12 +7,19 @@ import OnBoardingLanguageSelector from '../components/molecules/OnBoardingLangua
 import { useTranslation } from 'react-i18next';
 import OnBoardingItem from '../components/organisms/OnBoardingItem';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useNavigation } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { RootStackParamList } from '../navigation/types';
+import useAsyncEffect from '../hooks/useAsyncEffect';
 
 const OnBoardingScreen = () => {
   const [currentIndex, setCurrentIndex] = useState(0);
   const scrollX = useRef(new Animated.Value(0)).current;
   const { t } = useTranslation();
   const slidesRef = useRef(null);
+  const navigation =
+    useNavigation<NativeStackNavigationProp<RootStackParamList>>();
+  const [showOnboarding, setShowOnboarding] = useState(false);
 
   const viewableItemsChanged = useRef(({ viewableItems }) => {
     setCurrentIndex(viewableItems[0].index);
@@ -88,6 +95,16 @@ const OnBoardingScreen = () => {
     scrollTo(currentIndex);
   }, [currentIndex]);
 
+  useAsyncEffect(async () => {
+    const viewed = await AsyncStorage.getItem('viewedOnboarding');
+    if (viewed && JSON.parse(viewed)) {
+      navigation.navigate('SignInScreen');
+    } else {
+      setShowOnboarding(true);
+    }
+  }, []);
+
+  if (!showOnboarding) return null;
   return (
     <View flex={1} justifyContent="center" alignItems="center">
       <Image
@@ -139,7 +156,14 @@ const OnBoardingScreen = () => {
       )}
       {currentIndex === onBoardingSlides.length - 1 && (
         <View px={6} mb={10}>
-          <Button colorScheme="primary" width="80" size="lg">
+          <Button
+            colorScheme="primary"
+            width="80"
+            size="lg"
+            onPress={async () => {
+              navigation.navigate('SignInScreen');
+              AsyncStorage.setItem('viewedOnboarding', 'true');
+            }}>
             <Text bold fontWeight="600" fontSize="lg" color="#fff">
               {t('onBoarding.startButton')}
             </Text>

--- a/src/screens/ProfileEditScreen.tsx
+++ b/src/screens/ProfileEditScreen.tsx
@@ -28,7 +28,6 @@ import {
 } from '../utils/permission';
 import { client } from '../config/axiosConfig';
 import Alert, { AlertType } from '../components/organisms/Alert';
-import { getUser } from '../utils/user/user';
 
 // Temporary profile image
 const ProfilePic = require('../assets/images/profile.png');
@@ -118,7 +117,7 @@ const ProfileEditScreen = () => {
         type: profileImage.type
       });
       try {
-        const { data } = await client.post(`/user/profile/image`, formData);
+        const { data } = await client.post('/user/profile/image', formData);
         if (data) getUserProfile();
       } catch (error) {
         setShowImageUploadError(true);
@@ -128,7 +127,7 @@ const ProfileEditScreen = () => {
 
   const updateUserProfile = async (payload) => {
     try {
-      await client.patch('/user', payload);
+      await client.patch('/user/profile', payload);
       setShowSuccessAlert(true);
       getUserProfile();
     } catch (err) {

--- a/src/screens/SettingScreen.tsx
+++ b/src/screens/SettingScreen.tsx
@@ -17,6 +17,7 @@ import useAsyncEffect from '../hooks/useAsyncEffect';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RootStackParamList } from '../navigation/types';
+import { UserContext } from '../contexts/UserContext';
 
 const SettingScreen = () => {
   const { language, changeLanguage, isSoundEffectOn, setIsSoundEffectOn } =
@@ -34,6 +35,7 @@ const SettingScreen = () => {
   const [renderTourguide, setRenderTourguide] = useState(true);
   const navigation =
     useNavigation<NativeStackNavigationProp<RootStackParamList>>();
+  const { setUser } = useContext(UserContext);
   const guideStepCount = 4;
   let stepCount = 0;
 
@@ -205,8 +207,16 @@ const SettingScreen = () => {
         </TourGuideZone>
       )}
       <Spacer />
-      {/* Signou */}
-      <Button size="lg" variant="outline" colorScheme="secondary">
+      {/* Signout */}
+      <Button
+        size="lg"
+        variant="outline"
+        colorScheme="secondary"
+        onPress={() => {
+          AsyncStorage.setItem('token', '');
+          setUser(undefined);
+          navigation.replace('SignInScreen');
+        }}>
         {t('setting.signOut')}
       </Button>
       {renderTourguide && (

--- a/src/screens/SignInScreen.tsx
+++ b/src/screens/SignInScreen.tsx
@@ -10,7 +10,7 @@ import {
   Text,
   VStack
 } from 'native-base';
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useContext, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
@@ -21,11 +21,9 @@ import images from '../assets/images';
 import useDimensions from '../hooks/useDimensions';
 import { useTranslation } from 'react-i18next';
 import Ionicons from 'react-native-vector-icons/Ionicons';
-import { useNavigation } from '@react-navigation/native';
-import { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import { RootStackParamList } from '../navigation/types';
 import { signIn } from '../utils/auth';
 import { useAuthentication } from '../hooks/useAuthentication';
+import { UserContext } from '../contexts/UserContext';
 
 const SignInScreen = () => {
   const {
@@ -38,9 +36,7 @@ const SignInScreen = () => {
   const { ScreenWidth } = useDimensions();
   const { t } = useTranslation();
   const { setToken } = useAuthentication();
-  const navigation =
-    useNavigation<NativeStackNavigationProp<RootStackParamList>>();
-
+  const { getUserProfile } = useContext(UserContext);
   const [showPassword, setShowPassword] = useState<boolean>(false);
 
   const onFormSubmit = useCallback(async (data) => {
@@ -48,7 +44,7 @@ const SignInScreen = () => {
     const signInResponse = await signIn(phoneNumber, password);
     if (signInResponse?.data?.token) {
       setToken(signInResponse.data.token);
-      navigation.replace('TabNavigation');
+      await getUserProfile();
     } else {
       console.log(signInResponse);
       setError('phoneNumber', {


### PR DESCRIPTION
# Notes
- When a user opens the app, they will see the onBoarding screens once. 
- Once they click to get started, they will never see it again.
- When they sign in successfully, they will be redirected to their respective home screens
- They can now click signout, which will remove the token, set users to null, and navigate them back to the signing page

https://user-images.githubusercontent.com/53035529/160463570-401887c8-d35c-476d-9b65-e99d7bc64e28.mov