### PR TITLE
Adjust health analytics table label scale

### DIFF
--- a/src/screens/healthRecord/HealthRecordChart.tsx
+++ b/src/screens/healthRecord/HealthRecordChart.tsx
@@ -44,7 +44,8 @@ const HealthRecordChart = (props: Props) => {
     const datapoints = data.data.map((item) => {
       return item.value;
     });
-    if (datapoints && timeFrame) setLabels(getPeriodLable(data.data));
+    if (datapoints && timeFrame)
+      setLabels(getPeriodLable(data.data, timeFrame as TimeFrame));
     setDatasets([{ data: datapoints }]);
   };
 

--- a/src/utils/module/healthRecord.ts
+++ b/src/utils/module/healthRecord.ts
@@ -1,11 +1,26 @@
 import moment from 'moment';
+import { TimeFrame } from '../../constants/HealthRecordingConstants';
 import { HealthRecordData } from '../../interfaces/healthRecording';
 
-export function getPeriodLable(data: HealthRecordData[]) {
+export function getPeriodLable(data: HealthRecordData[], timeFrame: TimeFrame) {
   const LABEL_COUNT = 6;
   const interpolate = Math.ceil(data.length / LABEL_COUNT);
   const labels: string[] = [];
 
+  if (timeFrame === TimeFrame.YEAR || timeFrame === TimeFrame.ALL_TIME) {
+    data.forEach((val, index) => {
+      if (
+        index === 0 ||
+        index === data.length - 1 ||
+        index === Math.round((data.length - 1) / 2)
+      ) {
+        labels.push(moment(val.dateTime).format('DD/MM/YY') + '        ');
+      } else {
+        return labels.push('');
+      }
+    });
+    return labels;
+  }
   data.forEach((val, index) => {
     if (index % interpolate === 0) {
       labels.push(moment(val.dateTime).format('DD/MM'));


### PR DESCRIPTION
# Notes
When the user selects the "Year" or "All Time" timeframe on the Health Analtyics Screen, the chart label will be limited to 3 values including Start date, middle date, and end date. All of which are formatted in a "DD/MM/YY" format.

https://user-images.githubusercontent.com/53035529/162730200-ada2ccf3-831a-4399-8517-4aba6436567d.mov


