### PR TITLE
fix: app errors when no health analytics data is returned

### DIFF
--- a/src/screens/healthRecord/HealthRecordChart.tsx
+++ b/src/screens/healthRecord/HealthRecordChart.tsx
@@ -51,9 +51,10 @@ const HealthRecordChart = (props: Props) => {
     const datapoints = data.data.map((item) => {
       return item.value;
     });
-    if (datapoints && timeFrame)
+    if (datapoints.length && timeFrame) {
       setLabels(getPeriodLable(data.data, timeFrame as TimeFrame));
-    setDatasets([{ data: datapoints }]);
+      setDatasets([{ data: datapoints }]);
+    }
   };
 
   useEffect(() => {


### PR DESCRIPTION
# Note
- Fixes the issue when the app errors and freezes when the health record data for plotting the chart is empty.